### PR TITLE
Pdfminder.six upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         "fdfgen>=0.13.0",
         "jinja2>=2.8",
-        "pdfminer.six==20160202",
+        "pdfminer.six>=20160202",
         "Pillow>=3.2.0",
         "PyPDF2>=1.25.1",
         "reportlab>=3.3.0"


### PR DESCRIPTION
Allowing more recent versions of pdfminer.six.
That old version crashes on certain pdf files for me, whereas the more recent versions do not. 
